### PR TITLE
Restore the MediaTek no-video fix: 16 KB RX URBs via devourer + heap RX ring

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          # Init the direct submodules (devourer + wfb-ng) but NOT recursively:
+          # devourer's reference/* vendor-kernel submodules are only used by its
+          # extraction tooling / hardware tests, never compiled into the APK, and
+          # one of them currently pins an unpushed commit that breaks a recursive
+          # clone. wfb-ng has no nested submodules.
+          submodules: true
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/app/wfbngrtl8812/src/main/cpp/CMakeLists.txt
+++ b/app/wfbngrtl8812/src/main/cpp/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(devourer STATIC
         ${CMAKE_SOURCE_DIR}/devourer/src/SignalStop.cpp
         ${CMAKE_SOURCE_DIR}/devourer/src/WiFiDriver.cpp
         ${CMAKE_SOURCE_DIR}/devourer/src/PhyTableLoader.cpp
+        ${CMAKE_SOURCE_DIR}/devourer/src/LaCapture.cpp
 
         # --- Jaguar1 (RTL8812AU / 8811AU / 8821AU) ---
         ${CMAKE_SOURCE_DIR}/devourer/hal/hal8812a_fw.c
@@ -71,6 +72,7 @@ add_library(devourer STATIC
         ${CMAKE_SOURCE_DIR}/devourer/src/jaguar3/HalmacJaguar3Fw.cpp
         ${CMAKE_SOURCE_DIR}/devourer/src/jaguar3/HalmacJaguar3MacInit.cpp
         ${CMAKE_SOURCE_DIR}/devourer/src/jaguar3/RadioManagementJaguar3.cpp
+        ${CMAKE_SOURCE_DIR}/devourer/src/jaguar3/PhydmRuntimeJaguar3.cpp
         ${CMAKE_SOURCE_DIR}/devourer/src/jaguar3/PhyTableLoaderJaguar3.cpp
         ${CMAKE_SOURCE_DIR}/devourer/src/jaguar3/Phy8822cTables.cpp
         ${CMAKE_SOURCE_DIR}/devourer/src/jaguar3/Halrf8822c.cpp

--- a/app/wfbngrtl8812/src/main/cpp/WfbngLink.cpp
+++ b/app/wfbngrtl8812/src/main/cpp/WfbngLink.cpp
@@ -124,6 +124,12 @@ int WfbngLink::run(JNIEnv *env, jobject context, jint wifiChannel, jint bw, jint
     // The per-adapter advisory lock defaults to /tmp, which doesn't exist on
     // Android — use the app's files dir (same location as gs.key).
     cfg.usb.lock_dir = "/data/user/0/com.openipc.pixelpilot/files";
+    // Keep the RX ring on plain heap buffers. The zerocopy dev-mem path
+    // (libusb_dev_mem_alloc / USBDEVFS mmap) is unvalidated on Android vendor
+    // kernels; if the mmap succeeds but the HCD's zerocopy path is broken,
+    // the heap fallback never triggers. Heap is the behavior every working
+    // Android build has shipped.
+    cfg.usb.rx_zerocopy = false;
 
     rtl_devices[fd] = wifi_driver->CreateRtlDevice(dev_handle, ctx, nullptr, cfg);
     if (!rtl_devices.at(fd)) {


### PR DESCRIPTION
Fixes the #6 regression reported 2026-07-19 (no video on MediaTek devices came back on master builds).

## Root cause

#104 bumped the devourer submodule (`bbc7385` → `73f1cb4`, ~3.5 months) past the transport split that deleted `RtlUsbAdapter.cpp`. @floppyhammer's fix (devourer #19, shipped here via #97) had two halves:

- device-side USB RX aggregation capped ≤16 KB — **survived** the refactor
- host-side bulk-IN reads capped at 16 KB — **lost**: the new async RX ring posts 32 KB URBs

Some MediaTek xhci/usbfs stacks (Dimensity 810, Helio G99, MT6765) never complete a bulk-IN read larger than 16 KB — `LIBUSB_ERROR_TIMEOUT` forever, zero RX, no video. #104 was the first Android build of the async ring (its own description warned it was untested on hardware); the reports came straight back.

## Changes

- devourer submodule → `b7c50ec` (OpenIPC/devourer#317, tracked in OpenIPC/devourer#314): 16 KB URBs on all 11ac generations + matching Jaguar2/3 aggregation caps. Free on healthy hosts — with ≤16 KB aggregates a 32 KB URB never filled past 16 KB anyway.
- `WfbngLink.cpp`: `cfg.usb.rx_zerocopy = false` — keep the RX ring on plain heap buffers; the dev-mem zerocopy path is unvalidated on Android vendor kernels, and every previously working Android build shipped the heap path.

## Status

- [x] OpenIPC/devourer#317 merged (`b7c50ec`); submodule re-pinned to devourer master
- [ ] Test APK for the #6 volunteers (Dimensity 810 + MT6765), plus one Snapdragon no-regression check
- [ ] After confirmation: a release cut would help — #6 shows users building random master because the last release predates the fix era

🤖 Generated with [Claude Code](https://claude.com/claude-code)
